### PR TITLE
Set proper notification hints

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -31,7 +31,7 @@ msgid "Scale factor for protocol icon (0-100%)"
 msgstr "Facteur de redimensionnement de l’icône de protocole (0-100%)"
 
 #: ../src/purple-libnotify+-frames.c:54
-msgid "Do not use transcient notifications (if supported)"
+msgid "Do not use transient notifications (if supported)"
 msgstr "Ne pas utiliser les notifications éphémères (si supportées)"
 
 #: ../src/purple-libnotify+.c:37

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -30,7 +30,7 @@ msgid "Scale factor for protocol icon (0-100%)"
 msgstr "协议图标缩放系数 (0-100%)"
 
 #: ../src/purple-libnotify+-frames.c:54
-msgid "Do not use transcient notifications (if supported)"
+msgid "Do not use transient notifications (if supported)"
 msgstr "如果可以，延长通知的显示时间"
 
 #: ../src/purple-libnotify+.c:37

--- a/src/purple-libnotify+-common.h
+++ b/src/purple-libnotify+-common.h
@@ -32,7 +32,7 @@ struct
 	gboolean modify_notification;
 	gboolean use_svg;
 	gboolean overlay_icon;
-	gboolean set_transcient;
+	gboolean set_transient;
 	gboolean actions;
 } notify_plus_data;
 

--- a/src/purple-libnotify+-frames.c
+++ b/src/purple-libnotify+-frames.c
@@ -50,8 +50,8 @@ notify_plus_pref_frame(PurplePlugin *plugin)
 	purple_plugin_pref_set_bounds(pref, 0, 100);
 
 	pref = purple_plugin_pref_new_with_name_and_label(
-		"/plugins/core/libnotify+/no-transcient",
-		_("Do not use transcient notifications (if supported)")
+		"/plugins/core/libnotify+/no-transient",
+		_("Do not use transient notifications (if supported)")
 		);
 	purple_plugin_pref_frame_add(frame, pref);
 

--- a/src/purple-libnotify+-utils.c
+++ b/src/purple-libnotify+-utils.c
@@ -125,8 +125,8 @@ _notify_plus_send_notification_internal_v(
 		timeout = ( timeout == 0 ) ? NOTIFY_EXPIRES_NEVER : NOTIFY_EXPIRES_DEFAULT;
 	notify_notification_set_timeout(notification, timeout);
 
-	if ( notify_plus_data.set_transcient && ( ! purple_prefs_get_bool("/plugins/core/libnotify+/no-transcient") ) )
-		notify_notification_set_hint(notification, "transcient", g_variant_new_byte(1));
+	if ( notify_plus_data.set_transient && ( ! purple_prefs_get_bool("/plugins/core/libnotify+/no-transient") ) )
+		notify_notification_set_hint(notification, "transient", g_variant_new_byte(1));
 
 	if ( image != NULL )
 		notify_notification_set_image_from_pixbuf(notification, image);

--- a/src/purple-libnotify+-utils.c
+++ b/src/purple-libnotify+-utils.c
@@ -124,6 +124,7 @@ _notify_plus_send_notification_internal_v(
 	if ( timeout < 1 )
 		timeout = ( timeout == 0 ) ? NOTIFY_EXPIRES_NEVER : NOTIFY_EXPIRES_DEFAULT;
 	notify_notification_set_timeout(notification, timeout);
+	notify_notification_set_hint(notification, "x-canonical-append", g_variant_new_string("allowed"));
 
 	if ( notify_plus_data.set_transient && ( ! purple_prefs_get_bool("/plugins/core/libnotify+/no-transient") ) )
 		notify_notification_set_hint(notification, "transient", g_variant_new_byte(1));

--- a/src/purple-libnotify+.c
+++ b/src/purple-libnotify+.c
@@ -177,7 +177,7 @@ notify_plus_adapt_to_server_capabilities()
 	notify_plus_data.modify_notification = TRUE;
 	notify_plus_data.use_svg = FALSE;
 	notify_plus_data.overlay_icon = TRUE;
-	notify_plus_data.set_transcient = FALSE;
+	notify_plus_data.set_transient = FALSE;
 	notify_plus_data.actions = FALSE;
 
 	capabilities = notify_get_server_caps();
@@ -186,7 +186,7 @@ notify_plus_adapt_to_server_capabilities()
 		gchar *cap_name = capability->data;
 
 		if ( g_strcmp0(cap_name, "persistence") == 0 )
-			notify_plus_data.set_transcient = TRUE;
+			notify_plus_data.set_transient = TRUE;
 		else if ( g_strcmp0(cap_name, "image/svg+xml") == 0 )
 			notify_plus_data.use_svg = TRUE;
 		else if ( g_strcmp0(cap_name, "x-eventd-overlay-icon") == 0 )
@@ -408,7 +408,7 @@ init_plugin(PurplePlugin *plugin)
 	purple_prefs_add_none("/plugins/core/libnotify+");
 	purple_prefs_add_int("/plugins/core/libnotify+/expire-timeout", timeout);
 	purple_prefs_add_int("/plugins/core/libnotify+/overlay-scale", 50);
-	purple_prefs_add_bool("/plugins/core/libnotify+/no-transcient", FALSE);
+	purple_prefs_add_bool("/plugins/core/libnotify+/no-transient", FALSE);
 }
 
 PURPLE_INIT_PLUGIN(notify_plus, init_plugin, info)


### PR DESCRIPTION
The `transient` hint was added and made configurable, but misspelled as “transcient” and therefore nonfunctional.   a488a76 fixes that.

e3788ae also sets the `x-canonical-append` hint to `allowed`, which (on supporting daemons, e.g., Unity's `notify-osd`) will display multiple successive notifications from the same contact merged into a single notification.
